### PR TITLE
Use MCR for all public container images

### DIFF
--- a/choreography/src/delivery/Dockerfile
+++ b/choreography/src/delivery/Dockerfile
@@ -35,7 +35,7 @@ RUN dotnet publish /app/Fabrikam.DroneDelivery.DeliveryService/ -c Release -o ..
 
 FROM base AS runtime
 
-LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
+LABEL Maintainer="Microsoft Patterns & Practices (https://github.com/mspnp)"
 
 LABEL Tags="Azure,AKS,DroneDelivery"
 

--- a/choreography/src/delivery/Dockerfile
+++ b/choreography/src/delivery/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime as base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 as base
 WORKDIR /app
 EXPOSE 8080
 
-FROM microsoft/dotnet:2.2-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 
 WORKDIR /app
 COPY Fabrikam.DroneDelivery.Common/*.csproj ./Fabrikam.DroneDelivery.Common/
@@ -28,14 +28,14 @@ ENTRYPOINT ["dotnet", "test", "--logger:trx"]
 
 FROM build AS publish
 
-MAINTAINER Fernando Antivero (https://github.com/ferantivero)
+LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
 
 WORKDIR /app
 RUN dotnet publish /app/Fabrikam.DroneDelivery.DeliveryService/ -c Release -o ../out
 
 FROM base AS runtime
 
-MAINTAINER Fernando Antivero (https://github.com/ferantivero)
+LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
 
 LABEL Tags="Azure,AKS,DroneDelivery"
 
@@ -45,14 +45,10 @@ RUN useradd -m -s /bin/bash -U $user
 
 WORKDIR /app
 COPY --from=publish /app/out ./
-COPY scripts/. ./
-RUN \
-    # Ensures the entry point is executable
-    chmod ugo+x /app/run.sh
 
 RUN chown -R $user.$user /app
 
 # Set it for subsequent commands
 USER $user
 
-ENTRYPOINT ["/bin/bash", "/app/run.sh"]
+ENTRYPOINT ["dotnet", "Fabrikam.DroneDelivery.DeliveryService.dll"]

--- a/choreography/src/delivery/scripts/run.sh
+++ b/choreography/src/delivery/scripts/run.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-dotnet Fabrikam.DroneDelivery.DeliveryService.dll

--- a/choreography/src/dronescheduler/Dockerfile
+++ b/choreography/src/dronescheduler/Dockerfile
@@ -19,14 +19,14 @@ COPY dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/. ./dronescheduler/Fab
 
 FROM build AS publish
 
-LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
+LABEL Maintainer="Microsoft Patterns & Practices (https://github.com/mspnp)"
 
 WORKDIR /app
 RUN dotnet publish /app/dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/ -c Release -o ../../out
 
 FROM base AS runtime
 
-LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
+LABEL Maintainer="Microsoft Patterns & Practices (https://github.com/mspnp)"
 
 LABEL Tags="Azure,AKS,DroneDelivery"
 

--- a/choreography/src/dronescheduler/Dockerfile
+++ b/choreography/src/dronescheduler/Dockerfile
@@ -1,32 +1,32 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime as base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.2-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 
-MAINTAINER Fernando Antivero (https://github.com/ferantivero)
-
-WORKDIR /app
-COPY delivery/Fabrikam.DroneDelivery.Common/*.csproj ./Fabrikam.DroneDelivery.Common/
-COPY dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/*.csproj ./Fabrikam.DroneDelivery.DroneScheduler/
-WORKDIR /app
-RUN dotnet restore /app/Fabrikam.DroneDelivery.Common/
-RUN dotnet restore /app/Fabrikam.DroneDelivery.DroneScheduler/
+LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
 
 WORKDIR /app
-COPY delivery/Fabrikam.DroneDelivery.Common/. ./Fabrikam.DroneDelivery.Common/
-COPY dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/. ./Fabrikam.DroneDelivery.DroneScheduler/
+COPY delivery/Fabrikam.DroneDelivery.Common/*.csproj ./delivery/Fabrikam.DroneDelivery.Common/
+COPY dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/*.csproj ./dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/
+WORKDIR /app
+RUN dotnet restore /app/delivery/Fabrikam.DroneDelivery.Common/
+RUN dotnet restore /app/dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/
+
+WORKDIR /app
+COPY delivery/Fabrikam.DroneDelivery.Common/. ./delivery/Fabrikam.DroneDelivery.Common/
+COPY dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/. ./dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/
 
 FROM build AS publish
 
-MAINTAINER Fernando Antivero (https://github.com/ferantivero)
+LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
 
 WORKDIR /app
-RUN dotnet publish /app/Fabrikam.DroneDelivery.DroneScheduler/ -c Release -o ../out
+RUN dotnet publish /app/dronescheduler/Fabrikam.DroneDelivery.DroneScheduler/ -c Release -o ../../out
 
 FROM base AS runtime
 
-MAINTAINER Fernando Antivero (https://github.com/ferantivero)
+LABEL Maintainer="Fernando Antivero (https://github.com/ferantivero)"
 
 LABEL Tags="Azure,AKS,DroneDelivery"
 
@@ -36,14 +36,10 @@ RUN useradd -m -s /bin/bash -U $user
 
 WORKDIR /app
 COPY --from=publish /app/out ./
-COPY dronescheduler/scripts/. ./
-RUN \
-    # Ensures the entry point is executable
-    chmod ugo+x /app/run.sh
 
 RUN chown -R $user.$user /app
 
 # Set it for subsequent commands
 USER $user
 
-ENTRYPOINT ["/bin/bash", "/app/run.sh"]
+ENTRYPOINT ["dotnet", "Fabrikam.DroneDelivery.DroneScheduler.dll"]

--- a/choreography/src/dronescheduler/scripts/run.sh
+++ b/choreography/src/dronescheduler/scripts/run.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-dotnet Fabrikam.DroneDelivery.DroneScheduler.dll

--- a/choreography/src/ingestion/Dockerfile
+++ b/choreography/src/ingestion/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8-jre-alpine as base
+FROM mcr.microsoft.com/java/jre:8-zulu-debian10 as base
 WORKDIR /usr/src/app
 EXPOSE 80
 
-FROM maven:3.5-jdk-8-slim as build
+FROM mcr.microsoft.com/java/maven:8-zulu-debian10 as build
 WORKDIR /usr/src/app
 
 COPY pom.xml ./


### PR DESCRIPTION
* Update all references to MCR
* Move to zulu for java runtime on ingestion (and get from MCR)
* Replace some of the ./run scripts with direct ENTRYPOINT calls.  They were failing before locally without them.  I left the run files in place in case someone wants to use them.
* Docker build wasn't behaving properly on choreography/src/dronescheduler/Dockerfile -- updated paths to stay in sync with the csproj file and out-of-root reference.
* Tested all builds