### PR TITLE
patch (deps): bug fix compilation issue and bump servicebus

### DIFF
--- a/async-request-reply/src/AsyncOperationStatusChecker.cs
+++ b/async-request-reply/src/AsyncOperationStatusChecker.cs
@@ -1,14 +1,13 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs.Specialized;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.Sas;
-using System.Linq;
 
 namespace Contoso
 {

--- a/async-request-reply/src/AsyncProcessingBackgroundWorker.cs
+++ b/async-request-reply/src/AsyncProcessingBackgroundWorker.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;

--- a/async-request-reply/src/AsyncProcessingBackgroundWorker.cs
+++ b/async-request-reply/src/AsyncProcessingBackgroundWorker.cs
@@ -1,9 +1,9 @@
 using System.IO;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
+using Azure.Storage.Blobs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using Azure.Storage.Blobs;
 
 namespace Contoso
 {

--- a/async-request-reply/src/AsyncProcessingWorkAcceptor.cs
+++ b/async-request-reply/src/AsyncProcessingWorkAcceptor.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
 using Azure.Messaging.ServiceBus;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;

--- a/async-request-reply/src/asyncpattern.csproj
+++ b/async-request-reply/src/asyncpattern.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.2.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
related: #625802

### WHY

we are doing some regular/proactive maintenance and while when we downloaded/compiled, it has failed. 

Additionally, we bump(ed) ServiceBus SDK.

### WHAT Changed?

- add threading using (required)
- bump **Microsoft.Azure.WebJobs.Extensions.ServiceBus** from **5.2.0** to **5.6.0**
- c# code conventions: sort and order using(s)
 
### HOW to Test?

you clone and open the async partner project and you can compile without errors