### PR TITLE
[Async-Request-Reply] feat (libs): [fw] [sdk] update to .NET6, AzFuncv4 & README

### DIFF
--- a/async-request-reply/README.md
+++ b/async-request-reply/README.md
@@ -11,8 +11,8 @@ For more information about this pattern, see [Asynchronous Request-Reply pattern
 ### Prerequisites
 
 - [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest)
-- [.NET Core SDK version 2.1](https://microsoft.com/net)
-- [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local#v2)
+- [.NET Core SDK version 6](https://dotnet.microsoft.com/en-us/download)
+- [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local#v4)
 
 ### Deploy the Azure resources
 

--- a/async-request-reply/README.md
+++ b/async-request-reply/README.md
@@ -27,20 +27,13 @@ For more information about this pattern, see [Asynchronous Request-Reply pattern
 3. Create a resource group.
 
     ```bash
-    export RESOURCE_GROUP=<resource-group-name>
-    export APP_NAME=<app-name> # 2-6 characters
-    export LOCATION=<azure-region>
-
-    az group create --name $RESOURCE_GROUP --location $LOCATION
+    az group create --name rg-asyncrequestreply --location eastus
     ```
 
 4. Deploy the template.
 
     ```bash
-    az group deployment create \
-    --resource-group $RESOURCE_GROUP \
-    --template-file deploy.json \
-    --parameters appName=$APP_NAME
+    az deployment group create -g rg-asyncrequestreply -f deploy.json
     ```
 
 5. Wait for the deployment to complete.
@@ -56,7 +49,9 @@ For more information about this pattern, see [Asynchronous Request-Reply pattern
 2. Deploy the app.
 
     ```bash
-    func azure functionapp publish $(APP_NAME)-fn
+    FUNC_APP_NAME=$(az deployment group show -g rg-asyncrequestreply -n deploy --query properties.outputs.functionAppName.value -o tsv)
+
+    func azure functionapp publish $FUNC_APP_NAME --dotnet
     ```
 
 ### Validate the Azure Function app
@@ -64,7 +59,7 @@ For more information about this pattern, see [Asynchronous Request-Reply pattern
 1. Send an http request through the Async Processor Work Acceptor
 
    ```bash
-   curl -X POST "https://$(APP_NAME)-fn.azurewebsites.net/api/asyncprocessingworkacceptor" --header 'Content-Type: application/json' --header 'Accept: application/json' -k -i -d '{
+   curl -X POST "https://${FUNC_APP_NAME}.azurewebsites.net/api/asyncprocessingworkacceptor" --header 'Content-Type: application/json' --header 'Accept: application/json' -k -i -d '{
       "id": "1234",
       "customername": "Contoso"
    }'

--- a/async-request-reply/README.md
+++ b/async-request-reply/README.md
@@ -66,3 +66,10 @@ For more information about this pattern, see [Asynchronous Request-Reply pattern
    ```
 
    > **Note** the app uses the WEBSITE_HOSTNAME environment variable. This environment variable is set automatically by the Azure App Service runtime environment. For more information, see [Azure runtime environment](https.://github.com/projectkudu/kudu/wiki/Azure-runtime-environment)
+
+### Clean up
+
+1. Delete all the Azure resources for this Cloud Async Pattern
+   ```bash
+   az group delete -n rg-asyncrequestreply -y
+   ```

--- a/async-request-reply/README.md
+++ b/async-request-reply/README.md
@@ -59,13 +59,15 @@ For more information about this pattern, see [Asynchronous Request-Reply pattern
     func azure functionapp publish $(APP_NAME)-fn
     ```
 
-### Send a request
+### Validate the Azure Function app
 
-```bash
-curl -X POST "https://$(APP_NAME)-fn.azurewebsites.net/api/asyncprocessingworkacceptor" --header 'Content-Type: application/json' --header 'Accept: application/json' -k -i -d '{
-   "id": "1234",
-   "customername": "Contoso"
- }'
- ```
+1. Send an http request through the Async Processor Work Acceptor
 
- > Note. The app uses the WEBSITE_HOSTNAME environment variable. This environment variable is set automatically by the Azure App Service runtime environment. For more information, see [Azure runtime environment](https.://github.com/projectkudu/kudu/wiki/Azure-runtime-environment)
+   ```bash
+   curl -X POST "https://$(APP_NAME)-fn.azurewebsites.net/api/asyncprocessingworkacceptor" --header 'Content-Type: application/json' --header 'Accept: application/json' -k -i -d '{
+      "id": "1234",
+      "customername": "Contoso"
+   }'
+   ```
+
+   > **Note** the app uses the WEBSITE_HOSTNAME environment variable. This environment variable is set automatically by the Azure App Service runtime environment. For more information, see [Azure runtime environment](https.://github.com/projectkudu/kudu/wiki/Azure-runtime-environment)

--- a/async-request-reply/deploy.json
+++ b/async-request-reply/deploy.json
@@ -1,24 +1,15 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
-    "parameters": {
-        "appName": {
-            "type": "string",
-            "minLength": 2,
-            "maxLength": 6,
-            "metadata": {
-                "description": "Specifies the name for the app."
-            }
-        }
-    },
+    "parameters": {},
     "variables": {
-        "appStorageAccountName": "[toLower(concat(parameters('appName'),uniqueString(subscription().subscriptionId, resourceGroup().id)))]",
+        "appStorageAccountName": "[toLower(concat('stoapp',uniqueString(subscription().subscriptionId, resourceGroup().id)))]",
         "appStorageAccountId": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('appStorageAccountName'))]",
-        "dataStorageAccountName": "[toLower(concat(parameters('appName'),'data',uniqueString(subscription().subscriptionId, resourceGroup().id)))]",
+        "dataStorageAccountName": "[toLower(concat('stodata',uniqueString(subscription().subscriptionId, resourceGroup().id)))]",
         "dataStorageAccountId": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('dataStorageAccountName'))]",
-        "hostingPlanName": "[parameters('appName')]",
-        "functionAppName": "[concat(parameters('appName'),'-fn')]",
-        "serviceBusNamespace": "[toLower(concat(parameters('appName'),'sb',uniqueString(subscription().subscriptionId, resourceGroup().id)))]"
+        "hostingPlanName": "app-reqrep",
+        "functionAppName": "[concat('fapp-reqrep-',uniqueString(subscription().subscriptionId, resourceGroup().id))]",
+        "serviceBusNamespace": "[toLower(concat('sb-reqrep-',uniqueString(subscription().subscriptionId, resourceGroup().id)))]"
     },
     "resources": [
         {
@@ -150,5 +141,10 @@
             }
           }
         ],
-    "outputs": {}
+    "outputs": {
+      "functionAppName": {
+        "type": "string",
+        "value": "[variables('functionAppName')]"
+      }
+    }
 }

--- a/async-request-reply/deploy.json
+++ b/async-request-reply/deploy.json
@@ -118,7 +118,7 @@
                   },
                   {
                     "name": "FUNCTIONS_EXTENSION_VERSION",
-                    "value": "~2"
+                    "value": "~4"
                   },
                   {
                     "name": "WEBSITE_NODE_DEFAULT_VERSION",

--- a/async-request-reply/src/asyncpattern.csproj
+++ b/async-request-reply/src/asyncpattern.csproj
@@ -4,8 +4,8 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>

--- a/async-request-reply/src/asyncpattern.csproj
+++ b/async-request-reply/src/asyncpattern.csproj
@@ -4,8 +4,8 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>

--- a/async-request-reply/src/asyncpattern.csproj
+++ b/async-request-reply/src/asyncpattern.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/async-request-reply/src/asyncpattern.csproj
+++ b/async-request-reply/src/asyncpattern.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
closes: #689782;#689783

## WHY

from the Cloud Pattern Request Reply Async  we wanted to update code to use a new LTS .NET Fwk version as well as a more recent infrastructure runtime version.

## WHAT Changed?

- upgrade code to use .NET Fwk 6 and nuget packages (including NewtonSoft)
- infrastructure upgrade to Azure Functions V4
- streamlined instructions so it looks similar to newer README rather than old approach using more param oriented instructions

## HOW to Test?

you clone this repo and now you can execute this example in less steps, and also end up cleanup all the infra to reduce costs.

It should also contribute closing open PRs such us #83 and #93.