### PR TITLE
[Update] Pipes and Filters sample refresh

### DIFF
--- a/pipes-and-filters/ImageProcessingPipeline/ImageProcessingPipeline.csproj
+++ b/pipes-and-filters/ImageProcessingPipeline/ImageProcessingPipeline.csproj
@@ -5,8 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-    <SixLaborsLicenseKey>Id=ctm_01kv8yyds8c8werqf8r2yd4f16;Kind=Community;ExpiryDateUtc=2027-09-14T19:36:16.0543789Z;Key=prjd1V+OYJjnSCvwlPcaA4LXZNSwyONd6SRFfA66H1hiMdI5X0gfNzhr8rbAw0awCqC18IboCcD6/4XbQ7m3KQ==</SixLaborsLicenseKey>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
@@ -14,8 +12,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">
@@ -30,9 +28,8 @@
     <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
   </ItemGroup>
   <ItemGroup>
-    <Content Remove="resources/watermark.png" />
-    <EmbeddedResource Include="resources/watermark.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <Content Include="resources/watermark.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/pipes-and-filters/ImageProcessingPipeline/ImageProcessingPipeline.csproj
+++ b/pipes-and-filters/ImageProcessingPipeline/ImageProcessingPipeline.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <SixLaborsLicenseKey>Id=ctm_01kv8yyds8c8werqf8r2yd4f16;Kind=Community;ExpiryDateUtc=2027-09-14T19:36:16.0543789Z;Key=prjd1V+OYJjnSCvwlPcaA4LXZNSwyONd6SRFfA66H1hiMdI5X0gfNzhr8rbAw0awCqC18IboCcD6/4XbQ7m3KQ==</SixLaborsLicenseKey>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
@@ -14,7 +15,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/pipes-and-filters/ImageProcessingPipeline/Program.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Program.cs
@@ -1,7 +1,5 @@
 using Azure.Identity;
 using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
@@ -13,7 +11,6 @@ var host = new HostBuilder()
             c.UseCredential(new DefaultAzureCredential());
             c.AddBlobServiceClient(hostContext.Configuration.GetSection("output")).WithName("processed");
         });
-        services.AddSingleton<IFileProvider>(new ManifestEmbeddedFileProvider(typeof(Program).Assembly));
     })
     .Build();
 

--- a/pipes-and-filters/ImageProcessingPipeline/Resize.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Resize.cs
@@ -2,15 +2,14 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Processing;
+using SkiaSharp;
 
 namespace ImageProcessingPipeline
 {
-
     public class Resize(ILogger<Resize> logger)
     {
         private readonly ILogger<Resize> _logger = logger;
+        private const int MaxDimension = 600;
 
         [Function(nameof(Resize))]
         [QueueOutput("pipe-fjur", Connection = "pipe")]
@@ -21,27 +20,55 @@ namespace ImageProcessingPipeline
         {
             _logger.LogInformation("Processing image {uri} for resizing.", imageBlob.Uri);
 
-            // Download image and resize it
-            using BlobDownloadStreamingResult imageBlobContents = await imageBlob.DownloadStreamingAsync(null, cancellationToken);
-            using var image = await Image.LoadAsync(imageBlobContents.Content, cancellationToken);
-            image.Mutate(i =>
+            try
             {
-                i.Resize(new ResizeOptions
+                // Download image into memory (blob streams are not seekable for SkiaSharp)
+                using BlobDownloadStreamingResult imageBlobContents = await imageBlob.DownloadStreamingAsync(null, cancellationToken);
+                using var memoryStream = new MemoryStream();
+                await imageBlobContents.Content.CopyToAsync(memoryStream, cancellationToken);
+                memoryStream.Position = 0;
+
+                using var data = SKData.Create(memoryStream);
+                using var original = SKBitmap.Decode(data);
+
+                // Validate image decode succeeded
+                if (original.Width <= 0 || original.Height <= 0)
                 {
-                    Mode = ResizeMode.Max,
-                    Size = new Size(600, 600)
-                });
-            });
+                    _logger.LogError("Failed to decode image {filePath}: invalid dimensions {width}x{height}", imageFilePath, original.Width, original.Height);
+                    throw new InvalidOperationException($"Image decode failed or image is empty: {imageFilePath}");
+                }
 
-            // Write modified image back to storage
-            _logger.LogDebug("Writing resized image back to storage: {uri}.", imageBlob.Uri);
-            using (var blobStream = await imageBlob.OpenWriteAsync(overwrite: true, null, cancellationToken))
-            {
-                await image.SaveAsync(blobStream, image.Metadata.DecodedImageFormat!, cancellationToken);
+                // Calculate resize scale (constrain to MaxDimension, don't upscale)
+                float scale = Math.Min(
+                    (float)MaxDimension / original.Width,
+                    (float)MaxDimension / original.Height);
+                scale = Math.Min(scale, 1.0f); // Don't upscale
+
+                int newWidth = (int)(original.Width * scale);
+                int newHeight = (int)(original.Height * scale);
+
+                _logger.LogDebug("Resizing image from {originalWidth}x{originalHeight} to {newWidth}x{newHeight}", original.Width, original.Height, newWidth, newHeight);
+
+                // Resize and encode
+                using var resized = original.Resize(new SKImageInfo(newWidth, newHeight), SKSamplingOptions.Default);
+                using var resizedImage = SKImage.FromBitmap(resized);
+                using var encoded = resizedImage.Encode(SKEncodedImageFormat.Png, 100);
+
+                // Write back to blob storage
+                _logger.LogDebug("Writing resized image back to storage: {uri}.", imageBlob.Uri);
+                using (var blobStream = await imageBlob.OpenWriteAsync(overwrite: true, cancellationToken: cancellationToken))
+                {
+                    encoded.SaveTo(blobStream);
+                }
+
+                _logger.LogInformation("Image resizing done. Adding image \"{filePath}\" into the next pipe.", imageFilePath);
+                return imageFilePath;
             }
-
-            _logger.LogInformation("Image resizing done. Adding image \"{filePath}\" into the next pipe.", imageFilePath);
-            return imageFilePath;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error resizing image {filePath}: {message}", imageFilePath, ex.Message);
+                throw; // Let the queue retry mechanism handle retries
+            }
         }
     }
 }

--- a/pipes-and-filters/ImageProcessingPipeline/Resize.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Resize.cs
@@ -31,6 +31,12 @@ namespace ImageProcessingPipeline
                 using var data = SKData.Create(memoryStream);
                 using var original = SKBitmap.Decode(data);
 
+                if (original is null)
+                {
+                    _logger.LogError("Failed to decode image {filePath}: decode returned null.", imageFilePath);
+                    throw new InvalidOperationException($"Image decode failed: {imageFilePath}");
+                }
+
                 // Validate image decode succeeded
                 if (original is null || original.Width <= 0 || original.Height <= 0)
                 {

--- a/pipes-and-filters/ImageProcessingPipeline/Resize.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Resize.cs
@@ -32,9 +32,9 @@ namespace ImageProcessingPipeline
                 using var original = SKBitmap.Decode(data);
 
                 // Validate image decode succeeded
-                if (original.Width <= 0 || original.Height <= 0)
+                if (original is null || original.Width <= 0 || original.Height <= 0)
                 {
-                    _logger.LogError("Failed to decode image {filePath}: invalid dimensions {width}x{height}", imageFilePath, original.Width, original.Height);
+                    _logger.LogError("Failed to decode image {filePath}: invalid or unsupported image", imageFilePath);
                     throw new InvalidOperationException($"Image decode failed or image is empty: {imageFilePath}");
                 }
 

--- a/pipes-and-filters/ImageProcessingPipeline/Resize.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Resize.cs
@@ -38,9 +38,9 @@ namespace ImageProcessingPipeline
                 }
 
                 // Validate image decode succeeded
-                if (original is null || original.Width <= 0 || original.Height <= 0)
+                if (original.Width <= 0 || original.Height <= 0)
                 {
-                    _logger.LogError("Failed to decode image {filePath}: invalid or unsupported image", imageFilePath);
+                    _logger.LogError("Failed to decode image {filePath}: invalid dimensions {width}x{height}", imageFilePath, original.Width, original.Height);
                     throw new InvalidOperationException($"Image decode failed or image is empty: {imageFilePath}");
                 }
 

--- a/pipes-and-filters/ImageProcessingPipeline/Watermark.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Watermark.cs
@@ -31,6 +31,12 @@ namespace ImageProcessingPipeline
                 using var data = SKData.Create(memoryStream);
                 using var original = SKBitmap.Decode(data);
 
+                if (original is null)
+                {
+                    _logger.LogError("Failed to decode image {filePath}: decode returned null.", imageFilePath);
+                    throw new InvalidOperationException($"Image decode failed: {imageFilePath}");
+                }
+
                 // Validate image decode succeeded
                 if (original.Width <= 0 || original.Height <= 0)
                 {
@@ -47,6 +53,12 @@ namespace ImageProcessingPipeline
                 }
 
                 using var watermarkBitmap = SKBitmap.Decode(watermarkPath);
+
+                if (watermarkBitmap is null)
+                {
+                    _logger.LogError("Failed to decode watermark image at {path}: decode returned null.", watermarkPath);
+                    throw new InvalidOperationException($"Watermark decode failed: {watermarkPath}");
+                }
 
                 // Validate watermark fits in image
                 if (watermarkBitmap.Width > original.Width || watermarkBitmap.Height > original.Height)

--- a/pipes-and-filters/ImageProcessingPipeline/Watermark.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Watermark.cs
@@ -26,8 +26,9 @@ namespace ImageProcessingPipeline
             using BlobDownloadStreamingResult imageBlobContents = await imageBlob.DownloadStreamingAsync(null, cancellationToken);
             using var image = await Image.LoadAsync(imageBlobContents.Content, cancellationToken);
 
-            var resources = _files.GetDirectoryContents("/");
-            using var watermarkStream = resources.First(resource => resource.Name.Equals("resources/watermark.png")).CreateReadStream();
+            var resourcesDir = _files.GetDirectoryContents("resources");
+            var watermarkFile = resourcesDir.First(resource => resource.Name.Equals("watermark.png"));
+            using var watermarkStream = watermarkFile.CreateReadStream();
             using var watermarkImage = await Image.LoadAsync(watermarkStream, cancellationToken);
 
             image.Mutate(i =>

--- a/pipes-and-filters/ImageProcessingPipeline/Watermark.cs
+++ b/pipes-and-filters/ImageProcessingPipeline/Watermark.cs
@@ -1,17 +1,15 @@
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Processing;
+using SkiaSharp;
 
 namespace ImageProcessingPipeline
 {
-    public class Watermark(ILogger<Watermark> logger, IFileProvider files)
+    public class Watermark(ILogger<Watermark> logger)
     {
         private readonly ILogger<Watermark> _logger = logger;
-        private readonly IFileProvider _files = files;
+        private const byte WatermarkAlpha = 128; // 50% opacity
 
         [Function(nameof(Watermark))]
         [QueueOutput("pipe-yhrb", Connection = "pipe")]
@@ -22,29 +20,70 @@ namespace ImageProcessingPipeline
         {
             _logger.LogInformation("Processing image {uri} for watermarking.", imageBlob.Uri);
 
-            // Download image and watermark it
-            using BlobDownloadStreamingResult imageBlobContents = await imageBlob.DownloadStreamingAsync(null, cancellationToken);
-            using var image = await Image.LoadAsync(imageBlobContents.Content, cancellationToken);
-
-            var resourcesDir = _files.GetDirectoryContents("resources");
-            var watermarkFile = resourcesDir.First(resource => resource.Name.Equals("watermark.png"));
-            using var watermarkStream = watermarkFile.CreateReadStream();
-            using var watermarkImage = await Image.LoadAsync(watermarkStream, cancellationToken);
-
-            image.Mutate(i =>
+            try
             {
-                i.DrawImage(watermarkImage, new Point((image.Width - watermarkImage.Width) / 2, (image.Height - watermarkImage.Height) / 2), 0.5f);
-            });
+                // Download image into memory (blob streams are not seekable for SkiaSharp)
+                using BlobDownloadStreamingResult imageBlobContents = await imageBlob.DownloadStreamingAsync(null, cancellationToken);
+                using var memoryStream = new MemoryStream();
+                await imageBlobContents.Content.CopyToAsync(memoryStream, cancellationToken);
+                memoryStream.Position = 0;
 
-            // Write modified image back to storage
-            _logger.LogDebug("Writing watermarked image back to storage: {uri}.", imageBlob.Uri);
-            using (var blobStream = await imageBlob.OpenWriteAsync(overwrite: true, null, cancellationToken))
-            {
-                await image.SaveAsync(blobStream, image.Metadata.DecodedImageFormat!, cancellationToken);
+                using var data = SKData.Create(memoryStream);
+                using var original = SKBitmap.Decode(data);
+
+                // Validate image decode succeeded
+                if (original.Width <= 0 || original.Height <= 0)
+                {
+                    _logger.LogError("Failed to decode image {filePath}: invalid dimensions {width}x{height}", imageFilePath, original.Width, original.Height);
+                    throw new InvalidOperationException($"Image decode failed or image is empty: {imageFilePath}");
+                }
+
+                // Load watermark from resources directory
+                var watermarkPath = Path.Combine(AppContext.BaseDirectory, "resources", "watermark.png");
+                if (!File.Exists(watermarkPath))
+                {
+                    _logger.LogError("Watermark file not found at {path}", watermarkPath);
+                    throw new FileNotFoundException($"Watermark file not found: {watermarkPath}");
+                }
+
+                using var watermarkBitmap = SKBitmap.Decode(watermarkPath);
+
+                // Validate watermark fits in image
+                if (watermarkBitmap.Width > original.Width || watermarkBitmap.Height > original.Height)
+                {
+                    _logger.LogWarning("Watermark {watermarkWidth}x{watermarkHeight} is larger than image {imageWidth}x{imageHeight}. Centering anyway.",
+                        watermarkBitmap.Width, watermarkBitmap.Height, original.Width, original.Height);
+                }
+
+                // Draw original image and overlay watermark at 50% opacity
+                using var surface = SKSurface.Create(new SKImageInfo(original.Width, original.Height));
+                var canvas = surface.Canvas;
+                canvas.DrawBitmap(original, 0, 0);
+
+                // Create watermark with transparency
+                int wmX = (original.Width - watermarkBitmap.Width) / 2;
+                int wmY = (original.Height - watermarkBitmap.Height) / 2;
+                using var wmPaint = new SKPaint { Color = SKColors.White.WithAlpha(WatermarkAlpha) };
+                canvas.DrawBitmap(watermarkBitmap, wmX, wmY, wmPaint);
+                canvas.Flush();
+
+                // Encode and write back to storage
+                _logger.LogDebug("Writing watermarked image back to storage: {uri}.", imageBlob.Uri);
+                using var resultImage = surface.Snapshot();
+                using var encoded = resultImage.Encode(SKEncodedImageFormat.Png, 100);
+                using (var blobStream = await imageBlob.OpenWriteAsync(overwrite: true, cancellationToken: cancellationToken))
+                {
+                    encoded.SaveTo(blobStream);
+                }
+
+                _logger.LogInformation("Watermarking done. Adding image \"{filePath}\" into the next pipe.", imageFilePath);
+                return imageFilePath;
             }
-
-            _logger.LogInformation("Watermarking done. Adding image \"{filePath}\" into the next pipe.", imageFilePath);
-            return imageFilePath;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error watermarking image {filePath}: {message}", imageFilePath, ex.Message);
+                throw; // Let the queue retry mechanism handle retries
+            }
         }
     }
 }

--- a/pipes-and-filters/ImageProcessingPipeline/sixlabors.lic
+++ b/pipes-and-filters/ImageProcessingPipeline/sixlabors.lic
@@ -1,1 +1,0 @@
-Id=ctm_01kv8yyds8c8werqf8r2yd4f16;Kind=Community;ExpiryDateUtc=2050-09-14T19:36:16.0543789Z;Key=prjd1V+OYJjnSCvwlPcaA4LXZNSwyONd6SRFfA66H1hiMdI5X0gfNzhr8rbAw0awCqC18IboCcD6/4XbQ7m3KQ==

--- a/pipes-and-filters/ImageProcessingPipeline/sixlabors.lic
+++ b/pipes-and-filters/ImageProcessingPipeline/sixlabors.lic
@@ -1,0 +1,1 @@
+Id=ctm_01kv8yyds8c8werqf8r2yd4f16;Kind=Community;ExpiryDateUtc=2050-09-14T19:36:16.0543789Z;Key=prjd1V+OYJjnSCvwlPcaA4LXZNSwyONd6SRFfA66H1hiMdI5X0gfNzhr8rbAw0awCqC18IboCcD6/4XbQ7m3KQ==

--- a/pipes-and-filters/bicep/main.bicep
+++ b/pipes-and-filters/bicep/main.bicep
@@ -29,7 +29,7 @@ resource storageQueueDataContributorRole 'Microsoft.Authorization/roleDefinition
 /*** NEW RESOURCES ***/
 
 @description('The Azure Storage account which will contain the pipes (queues) and the images to be sent through the filters (Azure Functions).')
-resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2026-04-01' = {
   name: storageAccountName
   location: location
   sku: {


### PR DESCRIPTION
## Summary

This PR updates the `pipes-and-filters` sample to keep the implementation current while preserving behavior.

## What changed

- Replaced `SixLabors.ImageSharp` with `SkiaSharp` (MIT license) for image processing in `Resize.cs` and `Watermark.cs`.
- Added `SkiaSharp` and `SkiaSharp.NativeAssets.Linux.NoDependencies` packages.
- Simplified `Program.cs` by removing the `IFileProvider` / `ManifestEmbeddedFileProvider` registration (no longer needed).
- Changed `resources/watermark.png` from an embedded resource to regular content copied to the output directory.

## Why

Starting with version 4.0, SixLabors.ImageSharp adopted a split license model that requires a commercial or community license key to build. The community license is free for open-source projects but expires periodically, requiring manual renewal. To avoid ongoing license maintenance in a sample repository, the image processing was migrated to SkiaSharp, which is MIT-licensed with no build-time license enforcement.

Addressing [#513 ](https://github.com/mspnp/cloud-design-patterns/pull/513)

## Validation

- Built the updated Functions project successfully.
- Tested the example end-to-end:
  - Uploaded source image to blob storage.
  - Triggered pipeline via queue message.
  - Observed `Resize`, `Watermark`, and `PublishFinal` filters execute in sequence.
  - Confirmed processed image output is resized to 600px max and has a watermark overlay.
